### PR TITLE
Add ESLint Import simple sort 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,9 +19,6 @@
   "rules": {
     "no-console": "warn",
 
-    "import/first": "error",
-    "import/newline-after-import": "error",
-    "import/no-duplicates": "error",
     "simple-import-sort/exports": "warn",
     "simple-import-sort/imports": [
       "warn",

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,38 +9,44 @@
     }
   },
   "extends": [
-    // "eslint:recommended",
-    // "plugin:react/recommended",
-    // "plugin:react/jsx-runtime",
-    // "plugin:react-hooks/recommended",
-    // "plugin:jsx-a11y/recommended",
-    // "prettier"
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:react/jsx-runtime",
+    "plugin:jsx-a11y/recommended",
+    "prettier"
   ],
   "rules": {
-    "no-console": "warn"
-    // "simple-import-sort/exports": "warn"
+    "no-console": "warn",
 
-    // "simple-import-sort/imports": [
-    //   "warn",
-    //   {
-    //     "groups": [
-    //       ["^react"],
-    //       ["^@?\\w"],
-    //       ["^src/?\\w"],
-    //       // Side effect imports.
-    //       ["^\\u0000"],
-    //       // Packages.
-    //       // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
-    //       ["^@?\\w"],
-    //       // Absolute imports and other imports such as Vue-style `@/foo`.
-    //       // Anything not matched in another group.
-    //       ["^"],
-    //       // Relative imports.
-    //       // Anything that starts with a dot.
-    //       ["^\\."]
-    //     ]
-    //   }
-    // ]
+    "import/first": "error",
+    "import/newline-after-import": "error",
+    "import/no-duplicates": "error",
+    "simple-import-sort/exports": "warn",
+    "simple-import-sort/imports": [
+      "warn",
+      {
+        "groups": [
+          // react import will be at top
+          ["^react"],
+          // Packages.
+          // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
+          ["^@?\\w"],
+          //components folder
+          ["^components/?\\w"],
+          //style folder
+          ["^styles/?\\w"],
+          // Side effect imports.
+          ["^\\u0000"],
+          // Absolute imports and other imports such as Vue-style `@/foo`.
+          // Anything not matched in another group.
+          ["^"],
+          // Relative imports.
+          // Anything that starts with a dot.
+          ["^\\."]
+        ]
+      }
+    ]
   },
   "settings": {
     "react": ""

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": [
+    "bradlc.vscode-tailwindcss",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "aaron-bond.better-comments"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
   "javascript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
https://github.com/lydell/eslint-plugin-simple-import-sort

This is ESLint will sort our import. We can use `cmd + .` to fix it manually, or save the file will automatically format it because I set it up in vscode settings.json. I mentioned in the comment where I put the setting
![CleanShot 2022-05-26 at 09 57 55](https://user-images.githubusercontent.com/22878284/170502711-3f46c38a-e0af-47b6-a7e8-e9d27cc4ecbe.gif)

The order of the import:
1. React import always will be first
2. NPM Package
3. components
4. styles
5. others

if you want to include a new folder in this sort, you need to update the `.eslintrc` code.
![CleanShot 2022-05-26 at 10 01 15](https://user-images.githubusercontent.com/22878284/170503181-c37df27e-db60-49aa-bdfc-730474888593.png)